### PR TITLE
Add missing CRLF epilogue

### DIFF
--- a/Sources/MultipartFormData/MultipartFormData.swift
+++ b/Sources/MultipartFormData/MultipartFormData.swift
@@ -120,7 +120,7 @@ extension MultipartFormData {
         let bodyData = body
             .map { ._dash + boundary._asciiData + ._crlf + $0._data + ._crlf }
             .reduce(Data(), +)
-        return bodyData + ._dash + boundary._asciiData + ._dash
+        return bodyData + ._dash + boundary._asciiData + ._dash + ._crlf
     }
 }
 

--- a/Tests/MultipartFormDataTests/MultipartFormDataTests.swift
+++ b/Tests/MultipartFormDataTests/MultipartFormDataTests.swift
@@ -39,7 +39,7 @@ final class MultipartFormDataTests: XCTestCase {
             "Content-Type: application/octet-stream",
             "",
             "",
-            "--test--"
+            "--test--\r\n"
         ].joined(separator: "\r\n").utf8)
         XCTAssertEqual(multipartFormData.httpBody, expectedBody)
     }
@@ -69,7 +69,7 @@ final class MultipartFormDataTests: XCTestCase {
             "Content-Type: application/octet-stream",
             "",
             "",
-            "--test--"
+            "--test--\r\n"
         ].joined(separator: "\r\n")
         XCTAssertEqual(multipartFormData.debugDescription, expectedDescription)
     }

--- a/Tests/MultipartFormDataTests/URLRequestTests.swift
+++ b/Tests/MultipartFormDataTests/URLRequestTests.swift
@@ -28,7 +28,7 @@ final class URLRequestTests: XCTestCase {
             "Content-Disposition: form-data; name=\"a\"",
             "",
             "",
-            "--test--",
+            "--test--\r\n",
         ].joined(separator: "\r\n").utf8)
         XCTAssertEqual(request.httpBody, expectedBody)
     }


### PR DESCRIPTION
Missing the extra CRLF that marks the end of the outer headers.
```
multipart-body := [preamble CRLF]
                  dash-boundary CRLF
                  body-part *encapsulation
                  close-delimiter
                  [CRLF epilogue]
```
See: https://datatracker.ietf.org/doc/html/rfc2046#page-22

If the server is using a strict parser, the request will fail. (such as Google)