### PR TITLE
[Feature] Sendable Conformances

### DIFF
--- a/Sources/MultipartFormData/Boundary.swift
+++ b/Sources/MultipartFormData/Boundary.swift
@@ -13,7 +13,7 @@ import Foundation
 /// 1. ``random()`` type method to generate a random one.
 /// 2. ``init(uncheckedBoundary:)`` to create one manually.
 ///   In this case an error can be thrown because it checks the required format!
-public struct Boundary: Hashable {
+public struct Boundary: Sendable, Hashable {
     internal let _asciiData: Data
 }
 

--- a/Sources/MultipartFormData/HTTPHeaderField.swift
+++ b/Sources/MultipartFormData/HTTPHeaderField.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A header field of an HTTP request.
-public protocol HTTPHeaderField: Hashable, CustomDebugStringConvertible {
+public protocol HTTPHeaderField: Sendable, Hashable, CustomDebugStringConvertible {
     
     /// The name of the header field.
     ///

--- a/Sources/MultipartFormData/HTTPHeaderParameter.swift
+++ b/Sources/MultipartFormData/HTTPHeaderParameter.swift
@@ -6,7 +6,7 @@
 //
 
 /// A parameter for an ``HTTPHeaderField``.
-public struct HTTPHeaderParameter: Hashable {
+public struct HTTPHeaderParameter: Sendable, Hashable {
     
     /// The name of the parameter.
     public var name: String

--- a/Sources/MultipartFormData/MediaType.swift
+++ b/Sources/MultipartFormData/MediaType.swift
@@ -12,7 +12,7 @@
 ///
 /// The most common once's are conveniently available through type properties.
 /// These can also be extended to avoid mistakes.
-public struct MediaType: Hashable {
+public struct MediaType: Sendable, Hashable {
     
     /// The type of media.
     public let type: String

--- a/Sources/MultipartFormData/MultipartFormData.swift
+++ b/Sources/MultipartFormData/MultipartFormData.swift
@@ -81,7 +81,7 @@ import Foundation
 /// <<png-data>>
 /// --example-boundary--
 /// ```
-public struct MultipartFormData: Hashable {
+public struct MultipartFormData: Sendable, Hashable {
     
     /// The boundary to separate the subparts of the ``body`` with.
     public let boundary: Boundary

--- a/Sources/MultipartFormData/Subpart.swift
+++ b/Sources/MultipartFormData/Subpart.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A subpart of the ``MultipartFormData``'s body.
 ///
 /// This can either be initialized the standard way or via the result builder initializer.
-public struct Subpart: Hashable {
+public struct Subpart: Sendable, Hashable {
     
     /// The content disposition of the subpart.
     public var contentDisposition: ContentDisposition


### PR DESCRIPTION
This PR conforms all types of this package to `Sendable`. This also fixes compilation of `MediaType`'s type properties in Swift 6 mode.