### PR TITLE
Fix `Data` concatenation error in Xcode 26.4 / Swift 6.3

### DIFF
--- a/Sources/MultipartFormData/MultipartFormData.swift
+++ b/Sources/MultipartFormData/MultipartFormData.swift
@@ -115,10 +115,19 @@ extension MultipartFormData {
     ///
     /// This combines all the data from the subparts into one big data object.
     public var httpBody: Data {
-        let bodyData: Data = body
-            .map { ._dash + boundary._asciiData + ._crlf + $0.data + ._crlf }
-            .reduce(Data(), +)
-        return bodyData + ._dash + boundary._asciiData + ._dash + ._crlf
+        var data = Data()
+        for subpart in body {
+            data.append(._dash)
+            data.append(boundary._asciiData)
+            data.append(._crlf)
+            data.append(subpart.data)
+            data.append(._crlf)
+        }
+        data.append(._dash)
+        data.append(boundary._asciiData)
+        data.append(._dash)
+        data.append(._crlf)
+        return data
     }
 }
 
@@ -162,7 +171,11 @@ extension MultipartFormData {
 
 extension MultipartFormData: CustomDebugStringConvertible {
     public var debugDescription: String {
-        let bytes: Data = contentType.data + ._crlf + ._crlf + httpBody
-        return String(bytes: bytes, encoding: .utf8) ?? ""
+        var data = Data()
+        data.append(contentType.data)
+        data.append(._crlf)
+        data.append(._crlf)
+        data.append(httpBody)
+        return String(bytes: data, encoding: .utf8) ?? ""
     }
 }

--- a/Sources/MultipartFormData/Subpart.swift
+++ b/Sources/MultipartFormData/Subpart.swift
@@ -89,7 +89,15 @@ extension Subpart: CustomDebugStringConvertible {
 extension Subpart {
     /// The data representation of a subpart.
     public var data: Data {
-        let contentTypeData: Data = contentType.map { $0.data + ._crlf } ?? Data()
-        return contentDisposition.data + ._crlf + contentTypeData + ._crlf + body
+        var data = Data()
+        data.append(contentDisposition.data)
+        data.append(._crlf)
+        if let contentType {
+            data.append(contentType.data)
+            data.append(._crlf)
+        }
+        data.append(._crlf)
+        data.append(body)
+        return data
     }
 }


### PR DESCRIPTION
Using `+` to concatenate data somehow causes a build error (`Binary operator '+' cannot be applied to two 'Data' operands`) in Xcode 26.4 / Swift 6.3. This replaces it with `append` as a workaround.